### PR TITLE
Added Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:6.7.0
+
+RUN npm install -g node-gyp
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY ./ /app/
+
+RUN npm install
+
+RUN cd node_modules/bcrypt && node-gyp rebuild && cd ../..
+
+ENTRYPOINT ["npm"]
+

--- a/config.development.js
+++ b/config.development.js
@@ -1,5 +1,7 @@
 import logger from './lib/logger';
 
+var dbHost = process.env.DB_HOST || '127.0.0.1';
+
 module.exports = {
   secret: '9080982%#@&^',
   jwtSession: { session: false },
@@ -7,7 +9,7 @@ module.exports = {
   username: 'danjesus',
   password: null,
   params: {
-    host: '127.0.0.1',
+    host: dbHost,
     dialect: 'postgres',
     logging: (sql) => {
       logger.info(`[${new Date()}] ${sql}`);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+services:
+  whishlist:
+    build: ./
+    ports:
+      - 3000:3000
+    environment:
+      DB_HOST: db
+    depends_on:
+      - db
+    command: start
+
+  db:
+    image: postgres:9.6.0
+    environment:
+      POSTGRES_USER: danjesus
+      POSTGRES_DB: whishlist
+


### PR DESCRIPTION
Now you are able to start the app by using docker-compose by running
```
docker-compose build
docker-compose up
```

Tested and got response from Api

There is one caveat and that is the postgres image uses a couple of seconds to create the initial database and the app tries to connect before it is done, so it will fail the first time around. Running docker-compose a second time everything will be ok. This is a problem with the official postgres image, so not much to do except create some sort workaround in the app, maybe a reconnect if it fails?